### PR TITLE
[Nicky] [Sarama] Added several new metrics to see breakdown of Sarama latency numbers

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -809,8 +809,12 @@ func (b *Broker) write(buf []byte) (n int, err error) {
 }
 
 func (b *Broker) send(rb protocolBody, promiseResponse bool, responseHeaderVersion int16) (*responsePromise, error) {
+	connWaitStart := time.Now()
+
 	b.lock.Lock()
 	defer b.lock.Unlock()
+
+	b.updateConnLockWaitTimeMetric(time.Since(connWaitStart))
 
 	if b.conn == nil {
 		if b.connErr != nil {

--- a/broker.go
+++ b/broker.go
@@ -198,6 +198,7 @@ func (b *Broker) Open(conf *Config) error {
 		b.responseRate = metrics.GetOrRegisterMeter("response-rate", conf.MetricRegistry)
 		b.responseSize = getOrRegisterHistogram("response-size", conf.MetricRegistry)
 		b.requestsInFlight = metrics.GetOrRegisterCounter("requests-in-flight", conf.MetricRegistry)
+		b.connLockWaitTime = getOrRegisterHistogram("conn-lock-wait-time-in-ms", conf.MetricRegistry)
 		// Do not gather metrics for seeded broker (only used during bootstrap) because they share
 		// the same id (-1) and are already exposed through the global metrics above
 		if b.id >= 0 && !metrics.UseNilMetrics {
@@ -1570,6 +1571,7 @@ func (b *Broker) registerMetrics() {
 	b.brokerResponseSize = b.registerHistogram("response-size")
 	b.brokerRequestsInFlight = b.registerCounter("requests-in-flight")
 	b.brokerThrottleTime = b.registerHistogram("throttle-time-in-ms")
+	b.brokerConnLockWaitTime = b.registerHistogram("conn-lock-wait-time-in-ms")
 }
 
 func (b *Broker) unregisterMetrics() {


### PR DESCRIPTION
Sarama has a relatively high fan-out factors from the initial singleton input channel to per topic channels to per partition channels to per broker channels, at which point it grabs a physical connection to a destination Kafka broker to write the outgoing request to Kafka. This PR added a metric to measure the wait time for getting write access to the underlying connection to Kafka.

Additionally, I added several other metrics to see the components of the total request + response latency that Sarama sees for each request.
