### PR TITLE
fix(proto): handle V3 member metadata and empty owned partitions 

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -209,7 +209,7 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 	coordinator, err := c.client.Coordinator(c.groupID)
 	if err != nil {
 		if retries <= 0 {
-			return nil, err
+			return nil, fmt.Errorf("failed to get coordinator: %w", err)
 		}
 
 		return c.retryNewSession(ctx, topics, handler, retries, true)
@@ -240,7 +240,7 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 		if consumerGroupJoinFailed != nil {
 			consumerGroupJoinFailed.Inc(1)
 		}
-		return nil, err
+		return nil, fmt.Errorf("failed to join consumer group: %w", err)
 	}
 	if join.Err != ErrNoError {
 		if consumerGroupJoinFailed != nil {
@@ -285,7 +285,7 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 	if join.LeaderId == join.MemberId {
 		members, err := join.GetMembers()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to get group members: %w", err)
 		}
 
 		plan, err = c.balance(strategy, members)

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -165,7 +165,7 @@ func (c *consumerGroup) Consume(ctx context.Context, topics []string, handler Co
 
 	// Refresh metadata for requested topics
 	if err := c.client.RefreshMetadata(topics...); err != nil {
-		return err
+		return fmt.Errorf("failed to resfresh topic metadata: %w", err)
 	}
 
 	// Init session
@@ -173,7 +173,7 @@ func (c *consumerGroup) Consume(ctx context.Context, topics []string, handler Co
 	if err == ErrClosedClient {
 		return ErrClosedConsumerGroup
 	} else if err != nil {
-		return err
+		return fmt.Errorf("failed to init new session: %w", err)
 	}
 
 	// loop check topic partition numbers changed

--- a/consumer_group_members.go
+++ b/consumer_group_members.go
@@ -7,6 +7,8 @@ type ConsumerGroupMemberMetadata struct {
 	Topics          []string
 	UserData        []byte
 	OwnedPartitions []*OwnedPartition
+	GenerationID    int32
+	RackID          *string
 }
 
 func (m *ConsumerGroupMemberMetadata) encode(pe packetEncoder) error {
@@ -18,6 +20,27 @@ func (m *ConsumerGroupMemberMetadata) encode(pe packetEncoder) error {
 
 	if err := pe.putBytes(m.UserData); err != nil {
 		return err
+	}
+
+	if m.Version >= 1 {
+		if err := pe.putArrayLength(len(m.OwnedPartitions)); err != nil {
+			return err
+		}
+		for _, op := range m.OwnedPartitions {
+			if err := op.encode(pe); err != nil {
+				return err
+			}
+		}
+	}
+
+	if m.Version >= 2 {
+		pe.putInt32(m.GenerationID)
+	}
+
+	if m.Version >= 3 {
+		if err := pe.putNullableString(m.RackID); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -46,15 +69,26 @@ func (m *ConsumerGroupMemberMetadata) decode(pd packetDecoder) (err error) {
 			}
 			return err
 		}
-		if n == 0 {
-			return nil
-		}
-		m.OwnedPartitions = make([]*OwnedPartition, n)
-		for i := 0; i < n; i++ {
-			m.OwnedPartitions[i] = &OwnedPartition{}
-			if err := m.OwnedPartitions[i].decode(pd); err != nil {
-				return err
+		if n > 0 {
+			m.OwnedPartitions = make([]*OwnedPartition, n)
+			for i := 0; i < n; i++ {
+				m.OwnedPartitions[i] = &OwnedPartition{}
+				if err := m.OwnedPartitions[i].decode(pd); err != nil {
+					return err
+				}
 			}
+		}
+	}
+
+	if m.Version >= 2 {
+		if m.GenerationID, err = pd.getInt32(); err != nil {
+			return err
+		}
+	}
+
+	if m.Version >= 3 {
+		if m.RackID, err = pd.getNullableString(); err != nil {
+			return err
 		}
 	}
 
@@ -64,6 +98,16 @@ func (m *ConsumerGroupMemberMetadata) decode(pd packetDecoder) (err error) {
 type OwnedPartition struct {
 	Topic      string
 	Partitions []int32
+}
+
+func (m *OwnedPartition) encode(pe packetEncoder) error {
+	if err := pe.putString(m.Topic); err != nil {
+		return err
+	}
+	if err := pe.putInt32Array(m.Partitions); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (m *OwnedPartition) decode(pd packetDecoder) (err error) {

--- a/consumer_group_members_test.go
+++ b/consumer_group_members_test.go
@@ -89,7 +89,7 @@ func TestConsumerGroupMemberMetadataV1Decode(t *testing.T) {
 
 func TestConsumerGroupMemberMetadataV3Decode(t *testing.T) {
 	meta := new(ConsumerGroupMemberMetadata)
-	if err := decode(groupMemberMetadataV3NilOwned, meta, nil); err != nil {
+	if err := decode(groupMemberMetadataV3NilOwned, meta); err != nil {
 		t.Error("Failed to decode V3 data", err)
 	}
 }

--- a/consumer_group_members_test.go
+++ b/consumer_group_members_test.go
@@ -42,6 +42,16 @@ var (
 		0, 0, 0, 3, 0x01, 0x02, 0x03, // Userdata
 		0, 0, 0, 0, // OwnedPartitions KIP-429
 	}
+
+	groupMemberMetadataV3NilOwned = []byte{
+		0, 3, // Version
+		0, 0, 0, 1, // Topic array length
+		0, 3, 'o', 'n', 'e', // Topic one
+		0, 0, 0, 3, 0x01, 0x02, 0x03, // Userdata
+		0, 0, 0, 0, // OwnedPartitions KIP-429
+		0, 0, 0, 64, // GenerationID
+		0, 4, 'r', 'a', 'c', 'k', // RackID
+	}
 )
 
 func TestConsumerGroupMemberMetadata(t *testing.T) {
@@ -74,6 +84,13 @@ func TestConsumerGroupMemberMetadataV1Decode(t *testing.T) {
 	}
 	if err := decode(groupMemberMetadataV1Bad, meta); err != nil {
 		t.Error("Failed to decode V1 'bad' data", err)
+	}
+}
+
+func TestConsumerGroupMemberMetadataV3Decode(t *testing.T) {
+	meta := new(ConsumerGroupMemberMetadata)
+	if err := decode(groupMemberMetadataV3NilOwned, meta, nil); err != nil {
+		t.Error("Failed to decode V3 data", err)
 	}
 }
 


### PR DESCRIPTION
- Backport of https://github.com/IBM/sarama/pull/2618: fixing a bug when decoding member metadata, supporting newer version of the metadata
- Add more detailed errors

Testing
-------


This is useful in a consumer group mixing sarama and ukcl members. The ukcl members include the newer fields to their metadata. If a sarama member is the leader, it cannot compute the assignment and the whole consumer group is stalled

[Errors](https://ddstaging.datadoghq.com/logs?query=service%3Amerle%20kube_deployment%3Amerle-714c-dd-mcd%20status%3Aerror%20&agg_q=status%2Cservice&agg_q_source=base%2Cbase&cols=core_host%2Ccore_service&index=%2A&messageDisplay=inline&refresh_mode=paused&sort_m=%2C&sort_t=%2C&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&viz=pattern&x_missing=true%2Ctrue&from_ts=1706802977027&to_ts=1706803170943&live=false) happening without the patch:
![image](https://github.com/DataDog/sarama/assets/28675033/3c4663b1-5cef-4711-9ff2-00e15d38e2d4)
It's happening here: https://github.com/DataDog/sarama/blob/c65f63a45a6ed7dee2a2f74794c28d40c6ec6907/consumer_group.go#L286


With patch, no errors in the [logs](https://ddstaging.datadoghq.com/logs?query=service%3Amerle%20kube_deployment%3Amerle-714c-dd-mcd%20status%3Aerror%20%40error%3A%2Asession%2A%20&agg_q=status%2Cservice&agg_q_source=base%2Cbase&cols=core_host%2Ccore_service&index=%2A&messageDisplay=inline&refresh_mode=paused&sort_m=%2C&sort_t=%2C&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&viz=pattern&x_missing=true%2Ctrue&from_ts=1706803770622&to_ts=1706807370622&live=false) anymore

![image](https://github.com/DataDog/sarama/assets/28675033/8eb99026-6432-4ad7-8dcd-246b2af3d8a8)

